### PR TITLE
FIX: Showing goals of users with dots in their names

### DIFF
--- a/app/controllers/discourse_teambuild/teambuild_controller.rb
+++ b/app/controllers/discourse_teambuild/teambuild_controller.rb
@@ -9,9 +9,7 @@ module DiscourseTeambuild
     end
 
     def goals
-      user = params[:username].present? ?
-        User.find_by(username_lower: params[:username].downcase) :
-        current_user
+      user = params[:username].present? ? fetch_user_from_params : current_user
 
       goals = DiscourseTeambuild::Goals.all
       render json: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ DiscourseTeambuild::Engine.routes.draw do
   get '/about' => 'teambuild#index'
   get '/scores' => 'teambuild#scores'
   get '/goals' => 'teambuild#goals'
-  get '/goals/:username' => 'teambuild#goals'
+  get '/goals/:username' => 'teambuild#goals', constraints: { username: RouteFormat.username }
   put '/complete/:goal_id' => 'teambuild#complete'
   delete '/undo/:goal_id' => 'teambuild#undo'
 end


### PR DESCRIPTION
Usernames like, e.g. "b.bordeaux" 😉

Note: not tested on a live Discourse instance, just following the way username paths are handled in core.