### PR TITLE
Only show link in hamburger when user can access

### DIFF
--- a/app/controllers/discourse_teambuild/teambuild_controller.rb
+++ b/app/controllers/discourse_teambuild/teambuild_controller.rb
@@ -88,8 +88,7 @@ module DiscourseTeambuild
     protected
 
     def ensure_can_access
-      return if guardian.has_teambuild_access?
-      raise Discourse::InvalidAccess.new
+      raise Discourse::InvalidAccess.new unless guardian.has_teambuild_access?
     end
   end
 end

--- a/app/controllers/discourse_teambuild/teambuild_controller.rb
+++ b/app/controllers/discourse_teambuild/teambuild_controller.rb
@@ -88,14 +88,8 @@ module DiscourseTeambuild
     protected
 
     def ensure_can_access
-      raise Discourse::InvalidAccess.new unless SiteSetting.teambuild_enabled?
-
-      return if current_user.staff?
-
-      group = Group.find_by(name: SiteSetting.teambuild_access_group)
-      if group.blank? || !group.group_users.where(user_id: current_user.id).exists?
-        raise Discourse::InvalidAccess.new
-      end
+      return if guardian.has_teambuild_access?
+      raise Discourse::InvalidAccess.new
     end
   end
 end

--- a/assets/javascripts/initializers/setup-teambuilding.js.es6
+++ b/assets/javascripts/initializers/setup-teambuilding.js.es6
@@ -4,12 +4,15 @@ export default {
   name: "setup-teambuilding",
   initialize() {
     withPluginApi("0.8", api => {
-      api.decorateWidget("hamburger-menu:generalLinks", dec => {
-        return {
-          route: "teamBuild.progress",
-          rawLabel: dec.widget.siteSettings.teambuild_name
-        };
-      });
+      const currentUser = api.getCurrentUser();
+      if (currentUser.has_teambuild_access) {
+        api.decorateWidget("hamburger-menu:generalLinks", dec => {
+          return {
+            route: "teamBuild.progress",
+            rawLabel: dec.widget.siteSettings.teambuild_name
+          };
+        });
+      }
     });
   }
 };

--- a/assets/javascripts/initializers/setup-teambuilding.js.es6
+++ b/assets/javascripts/initializers/setup-teambuilding.js.es6
@@ -5,7 +5,7 @@ export default {
   initialize() {
     withPluginApi("0.8", api => {
       const currentUser = api.getCurrentUser();
-      if (currentUser.has_teambuild_access) {
+      if (currentUser && currentUser.can_access_teambuild) {
         api.decorateWidget("hamburger-menu:generalLinks", dec => {
           return {
             route: "teamBuild.progress",

--- a/plugin.rb
+++ b/plugin.rb
@@ -16,3 +16,11 @@ register_asset 'stylesheets/team-build.scss'
 Discourse::Application.routes.append do
   mount ::DiscourseTeambuild::Engine, at: "/team-build"
 end
+
+after_initialize do
+  add_to_serializer(:current_user, :has_teambuild_access?) do
+    return true if scope.is_admin?
+    group = Group.find_by("lower(name) = ?", SiteSetting.teambuild_access_group.downcase)
+    return true if group && GroupUser.where(user_id: scope.user.id, group_id: group.id).exists?
+  end
+end


### PR DESCRIPTION
The "Team Building" link that displays in the hamburger menu should only display for a user when they have access to the Team Building feature. This change will check to make sure a user is either an admin, or part of the `teambuild_access_group` defined in the plugin's settings before rendering the link.