### PR TITLE
UX: Show different icon for incomplete tasks

### DIFF
--- a/assets/javascripts/discourse/templates/components/teambuild-choice.hbs
+++ b/assets/javascripts/discourse/templates/components/teambuild-choice.hbs
@@ -8,7 +8,7 @@
       {{#if completed}}
         {{d-button icon="check" action=(action "undo") class="btn-primary"}}
       {{else}}
-        {{d-button icon="check" action=(action "complete")}}
+        {{d-button icon="circle" action=(action "complete")}}
       {{/if}}
     {{/if}}
   </div>

--- a/assets/javascripts/discourse/templates/components/teambuild-choice.hbs
+++ b/assets/javascripts/discourse/templates/components/teambuild-choice.hbs
@@ -6,9 +6,9 @@
       {{/if}}
     {{else}}
       {{#if completed}}
-        {{d-button icon="check" action=(action "undo") class="btn-primary"}}
+        {{d-button icon="check" action=(action "undo") class="btn-primary" title="discourse_teambuild.progress.mark_incomplete"}}
       {{else}}
-        {{d-button icon="circle" action=(action "complete")}}
+        {{d-button icon="circle" action=(action "complete") title="discourse_teambuild.progress.mark_complete"}}
       {{/if}}
     {{/if}}
   </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -25,4 +25,6 @@ en:
         title: "Progress"
         completed: "Completed"
         none: "There is nothing to do right now. Things likely haven't been configured yet."
+        mark_complete: "Mark complete"
+        mark_incomplete: "Mark incomplete"
       complete: "Complete"


### PR DESCRIPTION
Rendering a check icon for incomplete tasks is confusing to users. Particularly before completing their first task, users see them all checked off. This change uses a different icon (circle) in attempts to resolve that confusion.