### PR TITLE
Use the non-globally exposed RSpec syntax

### DIFF
--- a/spec/requests/targets_controller_spec.rb
+++ b/spec/requests/targets_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe DiscourseTeambuild::TargetsController do
+RSpec.describe DiscourseTeambuild::TargetsController do
 
   it "returns 404 when anonymous" do
     SiteSetting.teambuild_enabled = true

--- a/spec/requests/teambuild_controller_spec.rb
+++ b/spec/requests/teambuild_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe DiscourseTeambuild::TeambuildController do
+RSpec.describe DiscourseTeambuild::TeambuildController do
 
   it "returns 403 when anonymous" do
     SiteSetting.teambuild_enabled = true


### PR DESCRIPTION
RSpec 4 won't expose global syntax, see https://github.com/rspec/rspec-core/pull/2803

### Why?

https://github.com/pirj/discourse/runs/7507041178?check_suite_focus=true#step:22:4613