### PR TITLE
DEV: Replace #pluck_first with #pick

### DIFF
--- a/app/controllers/discourse_teambuild/targets_controller.rb
+++ b/app/controllers/discourse_teambuild/targets_controller.rb
@@ -41,8 +41,8 @@ module DiscourseTeambuild
     end
 
     def swap_position
-      target_position = TeambuildTarget.where(id: params[:target_id]).pluck_first(:position)
-      other_position = TeambuildTarget.where(id: params[:other_id]).pluck_first(:position)
+      target_position = TeambuildTarget.where(id: params[:target_id]).pick(:position)
+      other_position = TeambuildTarget.where(id: params[:other_id]).pick(:position)
       raise Discourse::NotFound if target_position.nil? || other_position.nil?
 
       TeambuildTarget.transaction do

--- a/spec/requests/targets_controller_spec.rb
+++ b/spec/requests/targets_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe DiscourseTeambuild::TargetsController do
       end
 
       it "creates the object with a group" do
-        group_id = Group.pluck_first(:id)
+        group_id = Group.pick(:id)
         post "/team-build/targets.json",
              params: {
                teambuild_target: {


### PR DESCRIPTION
### What is this change?

We are retiring the freedom patch which added `#pluck_first` since this is now supported natively in Rails through `#pick`. This change replaces all usages in this plugin.