### PR TITLE
FIX: Ensure teambuild link appears and doesn't break teambuild url

### DIFF
--- a/assets/javascripts/initializers/setup-teambuilding.js
+++ b/assets/javascripts/initializers/setup-teambuilding.js
@@ -5,11 +5,14 @@ export default {
   initialize() {
     withPluginApi("0.8", (api) => {
       const currentUser = api.getCurrentUser();
+      const teamBuildName = api.container.lookup(
+        "service:site-settings"
+      ).teambuild_name;
       if (currentUser && currentUser.can_access_teambuild) {
-        api.decorateWidget("hamburger-menu:generalLinks", (dec) => {
+        api.decorateWidget("hamburger-menu:generalLinks", () => {
           return {
             route: "teamBuild.progress",
-            rawLabel: dec.widget.siteSettings.teambuild_name,
+            rawLabel: teamBuildName,
           };
         });
       }

--- a/test/javascripts/acceptance/manage-test.js
+++ b/test/javascripts/acceptance/manage-test.js
@@ -94,9 +94,8 @@ acceptance("Team Building: Manage", function (needs) {
 
     await click(".sidebar-more-section-links-details-summary");
 
-    assert.strictEqual(
-      query(".sidebar-section-link[data-link-name='team-building']").innerText,
-      "Team Building"
-    );
+    assert
+      .dom(".sidebar-section-link[data-link-name='team-building']")
+      .hasText("Team Building");
   });
 });

--- a/test/javascripts/acceptance/manage-test.js
+++ b/test/javascripts/acceptance/manage-test.js
@@ -7,7 +7,7 @@ import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
 acceptance("Team Building: Manage", function (needs) {
-  needs.user();
+  needs.user({ can_access_teambuild: true });
   needs.pretender((server, helper) => {
     server.get("/team-build/targets.json", () => {
       return helper.response(200, {
@@ -86,6 +86,17 @@ acceptance("Team Building: Manage", function (needs) {
     assert.strictEqual(
       query(".teambuild-target .target-name").innerText.trim(),
       "New Name"
+    );
+  });
+
+  test("has links in sidebar", async (assert) => {
+    await visit("/team-build/manage");
+
+    await click(".sidebar-more-section-links-details-summary");
+
+    assert.strictEqual(
+      query(".sidebar-section-link[data-link-name='team-building']").innerText,
+      "Team Building"
     );
   });
 });


### PR DESCRIPTION
We're seeing an error now

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'widget')
    at setup-teambuilding.js:18:1
    at PluginApi._deprecateDecoratingHamburgerWidgetLinks (plugin-api.js:543:59)
    at PluginApi.decorateWidget (plugin-api.js:521:10)
    at setup-teambuilding.js:15:1
 ```
 
 because of the hamburger deprecation causing site settings not being able to load from the `dec.widget.siteSettings`. I'm plugging this for now instead of using the new API because I'm not sure the deprecation strategy to switch this to the new API.. (and also what icon to use?)

Fixed:

<img width="235" alt="Screenshot 2023-10-19 at 5 52 26 PM" src="https://github.com/discourse/discourse-teambuild/assets/1555215/b7cb24b8-f943-4b84-88e8-011001f653f5">
