### PR TITLE
FIX: Migrate legacy hamburger menu links to sidebar

### DIFF
--- a/assets/javascripts/initializers/setup-teambuilding.js
+++ b/assets/javascripts/initializers/setup-teambuilding.js
@@ -5,14 +5,24 @@ export default {
   initialize() {
     withPluginApi("0.8", (api) => {
       const currentUser = api.getCurrentUser();
-      const teamBuildName = api.container.lookup(
-        "service:site-settings"
-      ).teambuild_name;
-      if (currentUser && currentUser.can_access_teambuild) {
-        api.decorateWidget("hamburger-menu:generalLinks", () => {
-          return {
-            route: "teamBuild.progress",
-            rawLabel: teamBuildName,
+      if (currentUser?.can_access_teambuild) {
+        api.addCommunitySectionLink((baseSectionLink) => {
+          return class TeambuildSectionLink extends baseSectionLink {
+            get name() {
+              return "team-building";
+            }
+
+            get route() {
+              return "teamBuild.progress";
+            }
+
+            get text() {
+              return this.siteSettings.teambuild_name;
+            }
+
+            get title() {
+              return this.siteSettings.teambuild_name;
+            }
           };
         });
       }

--- a/assets/javascripts/initializers/setup-teambuilding.js
+++ b/assets/javascripts/initializers/setup-teambuilding.js
@@ -8,21 +8,10 @@ export default {
       if (currentUser?.can_access_teambuild) {
         api.addCommunitySectionLink((baseSectionLink) => {
           return class TeambuildSectionLink extends baseSectionLink {
-            get name() {
-              return "team-building";
-            }
-
-            get route() {
-              return "teamBuild.progress";
-            }
-
-            get text() {
-              return this.siteSettings.teambuild_name;
-            }
-
-            get title() {
-              return this.siteSettings.teambuild_name;
-            }
+            name = "team-building";
+            route = "teamBuild.progress";
+            text = this.siteSettings.teambuild_name;
+            title = this.siteSettings.teambuild_name;
           };
         });
       }


### PR DESCRIPTION
The legacy hamburger menu, which is implemented using the `hamburger-menu` widget, is being removed from core, so we need to migrate all customizations that currently target the legacy hamburger menu to the new sidebar.

This PR migrates the link that the plugin adds to the legacy hamburger menu to the new sidebar.

Internal topic: t/113137.